### PR TITLE
remove dependencies that are not compatible with heroku-18

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -37,7 +37,7 @@ if [ ! -f $CACHE_FILE ]; then
   cd $IMAGE_MAGICK_DIR
   export CPPFLAGS="-I$INSTALL_DIR/include"
   export LDFLAGS="-L$INSTALL_DIR/lib"
-  ./configure --prefix=$INSTALL_DIR --without-gvc
+  ./configure --prefix=$INSTALL_DIR --without-gvc --without-djvu --without-wmf --without-openexr
   make && make install
   cd ..
   rm -rf $IMAGE_MAGICK_DIR


### PR DESCRIPTION
ImageMagick requires a few libraries at runtime that are only available at build time in heroku-18. See: https://devcenter.heroku.com/articles/stack-packages

1. libdjvulibre21 for DjVu
2. libwmf0.2-7 for WMF
3. libilmbase12 for OpenEXR

As a workaround, we remove support for these filetypes.
